### PR TITLE
Control parameters at the naive QNN

### DIFF
--- a/graddft_qnn/main.py
+++ b/graddft_qnn/main.py
@@ -145,7 +145,7 @@ if __name__ == "__main__":
         dft_qnn = DFTQNN(dev, gates_gen, measurement_expvals, gates_indices)
     else:
         z_measurements = NaiveDFTQNN.generate_Z_measurements(len(dev.wires))
-        dft_qnn = NaiveDFTQNN(dev, z_measurements)
+        dft_qnn = NaiveDFTQNN(dev, z_measurements, num_gates)
 
     # get a sample batch for initialization
     coeff_input = jnp.zeros((2 ** len(dev.wires),))


### PR DESCRIPTION
For given number of gates (parameters), I iterate single rotation X operators and two qubit gates in sequential.

I notice that it takes amount of time to train even in the 3-qubit case. It would be better to decrease the gates or iterations...